### PR TITLE
add middleware to redirect when an unauthenticated user accesses pages for users

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,7 @@
+export default function({store, redirect}) {
+  if (!store.state.auth.loggedIn) {
+    redirect('/login');
+  } else {
+    redirect('/home');
+  }
+}

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <div v-if="isAuthenticated">
-      <h1>Hi, {{ user.email }}!</h1>
-      id: {{ user.id }}, name: {{ user.username }}
+      <h1>Hi, {{ me.email }}!</h1>
+      id: {{ me.id }}, name: {{ me.username }}
       you're the member of this system since {{ joinedDate }}
     </div>
   </div>
@@ -13,15 +13,19 @@
   import moment from '~/plugins/moment'
 
   export default {
+    middleware: [
+      'auth',
+    ],
+
     data: () => ({
-      user: {}
+      me: {}
     }),
 
     apollo: {
-      user: {
+      me: {
         query: gql`
         query {
-          user {
+          me {
             created_at
             email
             id
@@ -50,7 +54,7 @@
         return this.$auth.loggedIn
       },
       joinedDate () {
-        let dateRes = this.user.created_at
+        let dateRes = this.me.created_at
         return moment(dateRes, "YYYY-MM-DD HH:mm:ss Z").format("YYYY年M月D日H時m分")
       }
     },


### PR DESCRIPTION


# 変更点
<!--- ここはコメントアウト、必要に応じて外してください --->
<!--- ## ライブラリの追加 --->
<!--- * --->

## 機能追加
* 未ログインのユーザーがログイン済みのユーザー向けのページにアクセスした時に`/login`へリダイレクトされるようにした
   + 参考(そのまま拝借): [Nuxt.js と auth-module で  OAuth 認証によるログインを実装する - プらチナの日記](https://blog.8tak4.com/post/176366654280/impl-oauth-nuxtjs)
* 上記実装を用いて`/home`でのリダイレクトを設定した


<!--- ## 機能修正 --->
<!--- * --->

# コメント
