### PR TITLE
create activity graph and add it to user page

### DIFF
--- a/apollo/queries/get_activities_query.gql
+++ b/apollo/queries/get_activities_query.gql
@@ -1,0 +1,14 @@
+query ($userId: ID!) {
+  activities(userId: $userId) {
+    date
+    contributions {
+      id
+      createdAt
+      finishedAt
+    }
+    tasks {
+      id
+      finishTime
+    }
+  }
+}

--- a/components/atoms/ActivitySquare.vue
+++ b/components/atoms/ActivitySquare.vue
@@ -1,0 +1,101 @@
+<template>
+	<div class="cell">
+		<li :class="{
+			high: score >= 15,
+			middle_high: score >= 10 && score < 15,
+			middle: score >= 5 && score < 10,
+			middle_low: score > 0 && score < 5,
+			low: score == 0
+		}"
+		v-on:mouseover="toggle_activeness"
+		v-on:mouseleave="toggle_activeness"></li>
+		<div class="detail" :class="{active:isActive}">
+			<span>スコア: </span>{{score}} | {{activity.date.format('YYYY-MM-DD dddd')}}
+		</div>
+	</div>
+</template>
+
+<style lang="scss" scoped>
+.cell {
+	position: relative;
+	li {
+		width: 100%;
+		height: 100%;
+		&.low {
+			background-color: #EBEDF0;
+		}
+		&.middle_low {
+			background-color: #C6E38B;
+		}
+		&.middle {
+			background-color: #7BC86F;
+		}
+		&.middle_high {
+			background-color: #499B3C;
+		}
+		&.high {
+			background-color: #2C6227;
+		}
+	}
+	.detail {
+		display: none;
+		position: absolute;
+		z-index: 10;
+		background-color: #333;
+		color: #ddd;
+		padding: 5px 8px;
+		border-radius: 3px;
+		font-size: 12px;
+		font-weight: 400;
+		left: 50%;
+		width: 180px;
+		margin-left: -90px;
+		margin-top: 5px;
+		opacity: .9;
+		text-align: center;
+		span {
+			font-weight: 600;
+		}
+	}
+	.active {
+		display: block;
+	}
+}
+</style>
+
+<script>
+	import moment from '~/plugins/moment'
+
+	export default {
+		data () {
+			return {
+				isActive: false,
+			}
+		},
+		props: {
+			activity: {
+				type: Object,
+				defaut: function () {
+					return {
+						date: moment(),
+						contributions: new Array,
+						tasks: new Array,
+					}
+				}
+			},
+		},
+		computed: {
+			score () {
+				return this.activity.contributions.length * 1 + this.activity.tasks.length * 2;
+			},
+			date() {
+				return this.activity.date.format('YYYY-MM-DD');
+			},
+		},
+		methods: {
+			toggle_activeness () {
+				this.isActive = !this.isActive
+			},
+		},
+	}
+</script>

--- a/components/molecules/ActivityGraph.vue
+++ b/components/molecules/ActivityGraph.vue
@@ -1,0 +1,170 @@
+<template>
+	<div class="card">
+		<div class="container">
+			<div class="graph">
+				<ul class="months" :style="month_widths">
+					<li class="empty"></li>
+					<li v-for="month in months" :key="month.id">{{month}}</li>
+				</ul>
+				<ul class="days">
+					<li>日</li>
+					<li>月</li>
+					<li>火</li>
+					<li>水</li>
+					<li>木</li>
+					<li>金</li>
+					<li>土</li>
+				</ul>
+				<ul class="squares">
+					<ActivitySquare v-for="activity in activities" :key="activity.id" :activity="activity" />
+				</ul>
+			</div>
+		</div>
+	</div>
+</template>
+
+<style lang="scss" scoped>
+	ul {
+		list-style: none;
+		padding: 0;
+	}
+	.card {
+		background-color: #fff;
+		margin: 13px 20px;
+		padding: 25px 35px;
+		border-radius: 5px;
+		border: 1px solid #ddd;
+		font-size: 9px;
+		font-weight: 400;
+		color: #333;
+		.container {
+			width: min-content;
+			margin: auto;
+			.graph {
+				display: inline-grid;
+				grid-template-areas: "empty months"
+									 "days squares";
+				grid-gap: 5px;
+				grid-template-columns: auto;
+				justify-content: center;
+				.months {
+					display: grid;
+					grid-area: months;
+					grid-auto-flow: column;
+				}
+				.days, .squares {
+					display: grid;
+					grid-template-rows: repeat(7, 10px);
+					grid-gap: 2px;
+				}
+				.days {
+					grid-area: days;
+					text-align: right;
+					line-height: 1;
+				}
+				.squares {
+					grid-area: squares;
+					grid-auto-flow: column;
+					grid-auto-columns: 10px;
+				}
+				.days li:nth-child(odd) {
+					visibility: hidden;
+				}
+			}
+		}
+	}
+</style>
+
+<script>
+	import ActivitySquare from '~/components/atoms/ActivitySquare.vue'
+	import moment from '~/plugins/moment'
+
+	import gql from 'graphql-tag'
+	import getActivitiesQuery from '~/apollo/queries/get_activities_query.gql'
+
+	export default {
+		data() {
+			return {
+				activities: [],
+				months: [],
+				month_widths: {},
+			}
+		},
+		props: {
+			userid: Number,
+		},
+		components: {
+			ActivitySquare,
+		},
+		mounted: function() {
+			// 今日の日付
+			let today = moment(new Date());
+			// 最初のセル(今日から1年前の週の日曜日)
+			let first_day = moment(new Date()).subtract(1, 'years').day(0);
+			// セルの初期化
+			// セルの個数
+			let days_count = today.diff(first_day, 'days')+1;
+			// activityの1年分の配列
+			let activities = [...Array(days_count+1).keys()].map(i => {
+				let obj = {};
+				obj['date'] = first_day.clone().add(i, 'days');
+				obj['contributions'] = [];
+				obj['tasks'] = [];
+				return obj;
+			});
+			// データの取得
+			this.$apollo.query({
+				query: getActivitiesQuery,
+				variables: {
+					userId: this.userid,
+				},
+			}).then(res => {
+				res.data.activities.map((val, idx) => {
+					let date = moment(val['date'], "YYYY-MM-DD HH:mm:ss Z");
+					let index = date.diff(first_day, 'days')+1;
+					activities[index]['contributions'] = val['contributions'];
+					activities[index]['tasks'] = val['tasks'];
+				});
+			}).catch(err => {
+				console.log(err);
+			})
+			this.activities = activities;
+
+			// 各月の表示位置の計算
+			// 各月初日のセルがある列の上に月名を表示したい
+
+			// グラフの列数
+			let columns_count = Math.ceil(days_count/7);
+			// 最初の月を求める
+			let first_month;
+			if (first_day.date() == 1) {
+				first_month = first_day;
+			} else {
+				first_month = first_day.clone().date(1).add(1, 'months');
+			}
+			// 各月の名前、位置の配列を作る
+			let months = [];
+			let positions = [];
+			[...Array(12).keys()].map(i  => {
+				let month = first_month.clone().add(i, 'months');
+				months.push(month.format('MMM'));
+				positions.push(Math.floor(month.diff(first_day, 'days')/7));
+			});
+			this.months = months;
+			// 各月の幅の配列を作る
+			let widths = [];
+			positions.map((val, idx) => {
+				if (idx == 0) {
+					widths.push(positions[idx]);
+				} else {
+					widths.push(positions[idx] - positions[idx-1]);
+				}
+			});
+			widths.push(columns_count - positions[positions.length - 1]);
+
+			this.month_widths['grid-template-columns'] = widths.map((val) => {
+				return `calc(12px * ${val})`
+			}).join(' ');
+		},
+	}
+</script>

--- a/pages/_userid/index.vue
+++ b/pages/_userid/index.vue
@@ -1,6 +1,9 @@
 <template>
     <div>
         <h1>{{user.username}}</h1>
+
+        <ActivityGraph :userid="Number(userid)" />
+
         <div v-for="group in user.groups" :key="group.id">
             <div class="card">
                 <h2>
@@ -8,7 +11,7 @@
                     <span class="star" v-for="n in group.importance" :key="n">★</span>
                 </h2>
                 <div class="tags">
-                    <TaskCardTag v-for="group_t in group.ancestorGroups" :key="group_t.id" :group="group_t"/>
+                    <TaskCardTag v-for="group_tag in group.ancestorGroups" :key="group_tag.id" :group="group_tag"/>
                 </div>
             </div>
         </div>
@@ -49,6 +52,9 @@ h1 {
     import moment from '~/plugins/moment'
     import UserInfo from '~/components/atoms/UserInfo.vue'
     import TaskCardTag from '~/components/atoms/TaskCardTag.vue'
+    import ActivityGraph from '~/components/molecules/ActivityGraph.vue'
+
+    import getActivitiesQuery from '~/apollo/queries/get_activities_query.gql'
 
     const getGroupsQuery = gql`
                     query($id: ID!){
@@ -74,7 +80,11 @@ h1 {
                 userid: this.$route.params.userid,
                 user: {
                     groups:[],
-                }
+                },
+                activities: [{
+                                    contributions: [],
+                                    tasks: [],
+                                }],
             }
         },
 
@@ -86,7 +96,6 @@ h1 {
                 },
             }).then(res => {
                 this.user = res.data.user;
-                console.log(this.group);
 			}).catch(err => {
 				console.log(err);
 			});
@@ -95,6 +104,7 @@ h1 {
         components: {
             UserInfo,
             TaskCardTag,
+            ActivityGraph,
         },
 
         methods: {


### PR DESCRIPTION
# 変更点
<!--- ここはコメントアウト、必要に応じて外してください --->
<!--- ## ライブラリの追加 --->
<!--- * --->

## 機能追加
* ユーザーページに活動グラフの追加
   ![2019-01-06 23 26 06](https://user-images.githubusercontent.com/20355551/50737280-8f05b680-120a-11e9-9a96-a175a4724ad0.png)
   + 日毎にコントリビューション数 + タスク数*2 でスコアを算出

<!--- ## 機能修正 --->
<!--- * --->

# コメント
